### PR TITLE
Add publish docker image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+  # release:
+  #   types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the codebase
+        uses: actions/checkout@v4
+      - name: Login to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/discount-bandit
+          flavor: |
+            latest=true
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,9 +5,9 @@ networks:
 
 services:
   discount-bandit:
+    image: ghcr.io/cybrarist/discount-bandit:latest
     build:
       context: .
-#    image: ./
     ports:
       - 8080:80
     networks:


### PR DESCRIPTION
This PR adds a github workflow, that builds and publishes a ready to use docker image.

You can see a sample run here:
https://github.com/TheZoker/Discount-Bandit/actions/runs/11806297079

A sample published image:
https://github.com/TheZoker/Discount-Bandit/pkgs/container/discount-bandit

Here is the official documentation:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images