### PR TITLE
docker-compose: install dependencies from within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN docker-php-ext-install   pcntl \
         bcmath \
         calendar \
         pdo_mysql \
+        sockets \
         zip
 
 COPY ./docker/base_supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt update && apt install -y supervisor  \
         chromium-driver \
         xvfb \
         xdg-utils \
+        wget \
         && apt-get clean
 
 
@@ -50,6 +51,12 @@ RUN docker-php-ext-install   pcntl \
         pdo_mysql \
         sockets \
         zip
+
+ENV GET_COMPOSER_VERSION="76a7060ccb93902cd7576b67264ad91c8a2700e2"
+ENV COMPOSER_VERSION=2.8.2
+
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/$GET_COMPOSER_VERSION/web/installer -O - -q | php -- --quiet --version="$COMPOSER_VERSION" \
+	&& mv composer.phar /usr/local/bin/composer
 
 COPY ./docker/base_supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/README.md
+++ b/README.md
@@ -53,5 +53,16 @@ https://discord.gg/VBMHvH8tuR
 ## Docker
 There is no docker image for beta, since i might need the flexibility to push updates or fix bugs.
 
+# docker-compose
+
+If you run docker-compose before creating a .env file, it will have created a '.env'.
+To fix it, just delete the .env folder and make sure you create your own .env file before running:
+```
+rm -rf .env
+cp .env.example .env
+```
+
+Don't forget to also populate the .env file with your own APP_KEY (a random 32 characters string).
+
 ## Sponsors
 ![Jetbrains](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       - discount-bandit
     volumes:
-      - ./database/database.sqlite:/app/database/database.sqlite
+      - ./database/:/app/database/
       - ./.env:/app/.env
     environment:
       DB_CONNECTION: sqlite

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
     volumes:
       - ./database/:/app/database/
       - ./.env:/app/.env
+      - ./logs:/logs
     environment:
       DB_CONNECTION: sqlite
       NTFY_CHANNEL_ID: ""

--- a/docker/base_supervisord.conf
+++ b/docker/base_supervisord.conf
@@ -1,8 +1,7 @@
 [supervisord]
 user=root
 nodaemon=true
-;logfile=/dev/stdout
-logfile_maxbytes=0
+logfile=/logs/supervisord_stdout.log
 pidfile=/var/run/supervisord.pid
 
 [program:octane]
@@ -13,10 +12,8 @@ autorestart=true
 priority=2
 stdout_events_enabled=true
 stderr_events_enabled=true
-;stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-;stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stdout_logfile=/logs/octane_stdout.log
+stderr_logfile=/logs/octane_stderr.log
 
 
 [program:scheduler]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+composer install
+
 if [ ! -f ".env" ] ||  ! grep -q . ".env" ; then
     cp .env.example .env
     php artisan key:generate --force


### PR DESCRIPTION
This MR brings in multiple changes that make it easier to deploy Discount-Bandit using docker-compose.

The goal is to be able to start from scratch and just run `docker-compose up`, and have Discount-Bandit up and running automatically without having to manually install dependencies or populate files (this is not fully achieved yet - see below).

Notably, it:
- Adds php extensions and compose in the Docker image so that the dependencies can later be installed using `composer` at runtime.
- Mount the entire database folder so that the `database.sqlite` file gets created automatically at startup.
- Documents the creation of the .env file. 

With these changes, what is left for the user to do to deploy the application is to:
- create the .env file (as documented in the README).
- populating APP_KEY (mentioned in the README).
- run `docker-compose up`.

