### PR TITLE
Fix Docker sqlite startup and route cache conflict

### DIFF
--- a/app/Notifications/ProductDiscounted.php
+++ b/app/Notifications/ProductDiscounted.php
@@ -39,8 +39,8 @@ class ProductDiscounted extends Notification
         public array $notification_reasons,
         public string $product_url = "",
     ) {
-        $this->product_temp_link = URL::temporarySignedRoute("products.show", now()->addMinutes(15), ['product' => $this->product_id]);
-        $this->product_temp_snooze = URL::temporarySignedRoute("products.snooze", today()->endOfDay(), ['product' => $this->product_id]);
+        $this->product_temp_link = URL::temporarySignedRoute("products.temp.show", now()->addMinutes(15), ['product' => $this->product_id]);
+        $this->product_temp_snooze = URL::temporarySignedRoute("products.temp.snooze", today()->endOfDay(), ['product' => $this->product_id]);
 
         $this->notification_title = "For Just {$this->currency_code} {$this->new_link->price} -  Discount For ".Str::words($this->product_name, 5);
         $this->notification_text = "{$this->product_name}, is at {$this->currency_code}{$this->new_link->price} <br>".

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,10 +17,11 @@ services:
     networks:
       - discount-bandit
     volumes:
-      - ./database/database.sqlite:/app/database/sqlite
+      - ./database/sqlite:/app/database/sqlite
       - ./logs:/logs
     environment:
       DB_CONNECTION: sqlite
+      DB_DATABASE: /app/database/sqlite/database.sqlite
       APP_TIMEZONE: UTC
       THEME_COLOR: Red
       APP_URL: "http://localhost:8080"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,7 @@ php artisan storage:link
 
 printenv > /etc/environment
 
-php artisan migrate --force --seed
+php artisan migrate --force --seed --seeder='Database\Seeders\DatabaseSeeder'
 
 php artisan optimize:clear
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,14 +8,14 @@ Route::withoutMiddleware('auth')->get('/feed', FeedController::class)->name('fee
 Route::middleware('signed')
     ->group(function () {
         Route::withoutMiddleware('auth')
-            ->get('temp/products/{product}', [\App\Http\Controllers\ProductController::class, 'show'])->name('products.show');
+            ->get('temp/products/{product}', [\App\Http\Controllers\ProductController::class, 'show'])->name('products.temp.show');
 
         //        Route::withoutMiddleware('auth')
         //            ->get('temp/groups/{group}', [\App\Http\Controllers\GroupController::class, 'show'])->name('groups.show');
 
         Route::withoutMiddleware('auth')
             ->get('temp/products/{product}/snooze', [\App\Http\Controllers\ProductController::class, 'snooze'])
-            ->name('products.snooze');
+            ->name('products.temp.snooze');
 
     });
 


### PR DESCRIPTION
Fixes #115

## Summary
- Mount the Docker sqlite directory instead of mounting a host file onto `/app/database/sqlite`, which is a directory in the image.
- Set `DB_DATABASE` to the sqlite file inside that mounted directory so fresh Docker/Kubernetes-equivalent installs persist to the expected path.
- Rename the temporary product signed-route names and notification references to avoid colliding with the existing product route names during `php artisan optimize`.

## Verification
- Reproduced the current Docker compose volume problem locally: file mount to `/app/database/sqlite` fails because the image path is a directory.
- With the corrected sqlite directory mount, the container proceeds through dependency install, migrations, `DatabaseSeeder`, `CurrencySeeder`, and `StoreSeeder`; the next startup failure was route-cache serialization from duplicate `products.show` names, addressed here.
- `git diff --check`
- Static assertions for compose sqlite path and route/notification name pairing
- `docker run --rm --entrypoint sh -v "$PWD:/app" -w /app cybrarist/discount-bandit:v4 -lc 'php -l routes/web.php && php -l app/Notifications/ProductDiscounted.php'`

I did not use any private deployment data or Kubernetes access.